### PR TITLE
Support Windows: Don't spawn .js directly, use node executable

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -10,8 +10,8 @@ var eslintPkg = require(eslintPkgLoc);
 
 var cmds = [
   {
-    name: path.resolve(path.join(eslintPkgLoc, "..", eslintPkg.bin.eslint || eslintPkg.bin)),
-    args: ["--config", "eslint-config-kittens", "."]
+    name: "node",
+    args: [path.resolve(path.join(eslintPkgLoc, "..", eslintPkg.bin.eslint || eslintPkg.bin)), "--config", "eslint-config-kittens", "."]
   }
 ];
 


### PR DESCRIPTION
This change gets Babylon's `test` and `lint` scripts to work on Windows.